### PR TITLE
Playerの歩くエフェクト追加とプレイヤー名表示

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,61 +1,53 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "plugin:react/recommended",
-        "standard-with-typescript",
-        'prettier',
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['plugin:react/recommended', 'standard-with-typescript', 'prettier'],
+  overrides: [],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+  plugins: ['react'],
+  ignorePatterns: ['.eslintrc.js'],
+  rules: {
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/no-misused-promises': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+    'import/prefer-default-export': 'off',
+    'import/extensions': [
+      'error',
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
     ],
-    "overrides": [
+    'react/jsx-filename-extension': [
+      'error',
+      {
+        extensions: ['.jsx', '.tsx'],
+      },
     ],
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module",
-        'tsconfigRootDir': __dirname,
-        'project': ['./tsconfig.json'],
-    },
-    "plugins": [
-        "react"
+    'react/react-in-jsx-scope': 'off',
+    'no-void': [
+      'error',
+      {
+        allowAsStatement: true,
+      },
     ],
-    "ignorePatterns": [
-        ".eslintrc.js"
-    ],
-    "rules": {
-        'no-use-before-define': "off",
-        "@typescript-eslint/no-use-before-define": "off",
-        '@typescript-eslint/no-unused-vars': 'off',
-        'import/prefer-default-export': "off",
-        'import/extensions': [
-            'error',
-            {
-                js: 'never',
-                jsx: 'never',
-                ts: 'never',
-                tsx: 'never',
-            },
-        ],
-        'react/jsx-filename-extension': [
-        'error',
-        {
-            extensions: ['.jsx', '.tsx'],
-        },
-        ],
-        'react/react-in-jsx-scope': 'off',
-        'no-void': [
-        'error',
-        {
-            allowAsStatement: true,
-        },
-        ],
-    },
-    settings: {
+  },
+  settings: {
     'import/resolver': {
-        node: {
+      node: {
         paths: ['src'],
-        extensions: ['.js', '.jsx', '.ts', '.tsx']
-        },
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
     },
-    },
+  },
 }

--- a/client/src/bombermanConfig.ts
+++ b/client/src/bombermanConfig.ts
@@ -25,6 +25,8 @@ export interface OnlinePlayer {
   y: number
   size: number
   direction: string
+  pastDirection: string
+  imageType: number
   speed: number
   numOfBombs: number
   bombPower: number

--- a/client/src/hooks/useDrawPlayers.ts
+++ b/client/src/hooks/useDrawPlayers.ts
@@ -44,6 +44,9 @@ const useDrawPlayers = (): [
     canvasSize: number
   ): Promise<void> => {
     context.clearRect(0, 0, canvasSize, canvasSize)
+    context.font = '10px serif'
+    context.textAlign = 'center'
+    context.fillStyle = 'white'
     const img = document.createElement('img')
     for (let i: number = 0; i < players.length; i++) {
       const player = players[i]
@@ -51,7 +54,10 @@ const useDrawPlayers = (): [
         img.src = src
         console.log(src)
       })
-      if (player.isAlive) context.drawImage(img, player.x, player.y, player.size, player.size)
+      if (player.isAlive) {
+        context.drawImage(img, player.x, player.y, player.size, player.size)
+        context.fillText(player.name, player.x + player.size / 2, player.y)
+      }
     }
   }
 

--- a/client/src/hooks/useDrawPlayers.ts
+++ b/client/src/hooks/useDrawPlayers.ts
@@ -1,14 +1,61 @@
 import playerFrontImg from '../assets/player-front.png'
+import playerFrontWalk1Img from '../assets/player-front-walk1.png'
+import playerFrontWalk2Img from '../assets/player-front-walk2.png'
+import playerBackImg from '../assets/player-back.png'
+import playerBackWalk1Img from '../assets/player-back-walk1.png'
+import playerBackWalk2Img from '../assets/player-back-walk2.png'
+import playerLeftImg from '../assets/player-left.png'
+import playerLeftWalkImg from '../assets/player-left-walk.png'
+import playerRightImg from '../assets/player-right.png'
+import playerRightWalkImg from '../assets/player-right-walk.png'
 import { OnlinePlayer } from '../bombermanConfig'
 
-const useDrawPlayers = (players: OnlinePlayer[], context: CanvasRenderingContext2D, canvasSize: number): void => {
-  context.clearRect(0, 0, canvasSize, canvasSize)
-  const img = document.createElement('img')
-  img.src = playerFrontImg
-  for (let i: number = 0; i < players.length; i++) {
-    const player = players[i]
-    if (player.isAlive) context.drawImage(img, player.x, player.y, player.size, player.size)
+const useDrawPlayers = (): [
+  (players: OnlinePlayer[], context: CanvasRenderingContext2D, canvasSize: number) => Promise<void>
+] => {
+  const changePlayerImg = async (player: OnlinePlayer): Promise<string> => {
+    let src: string = playerFrontImg
+    if (player.direction === 'stay') {
+      if (player.pastDirection === 'up') src = playerBackImg
+      if (player.pastDirection === 'down') src = playerFrontImg
+      else if (player.pastDirection === 'left') src = playerLeftImg
+      else if (player.pastDirection === 'right') src = playerRightImg
+    } else {
+      const random = Math.random()
+      if (player.direction === 'down') {
+        src = player.imageType === 1 ? playerFrontWalk2Img : playerFrontWalk1Img
+      } else if (player.direction === 'up') {
+        src = player.imageType === 1 ? playerBackWalk2Img : playerBackWalk1Img
+      } else if (player.direction === 'left') {
+        src = player.imageType === 1 ? playerLeftWalkImg : playerLeftImg
+      } else if (player.direction === 'right') {
+        src = player.imageType === 1 ? playerRightWalkImg : playerRightImg
+      }
+    }
+
+    return await new Promise((resolve) => {
+      resolve(src)
+    })
   }
+
+  const drawPlayersOnCanvas = async (
+    players: OnlinePlayer[],
+    context: CanvasRenderingContext2D,
+    canvasSize: number
+  ): Promise<void> => {
+    context.clearRect(0, 0, canvasSize, canvasSize)
+    const img = document.createElement('img')
+    for (let i: number = 0; i < players.length; i++) {
+      const player = players[i]
+      await changePlayerImg(player).then((src) => {
+        img.src = src
+        console.log(src)
+      })
+      if (player.isAlive) context.drawImage(img, player.x, player.y, player.size, player.size)
+    }
+  }
+
+  return [drawPlayersOnCanvas]
 }
 
 export default useDrawPlayers

--- a/client/src/models/Enemies.tsx
+++ b/client/src/models/Enemies.tsx
@@ -1,5 +1,5 @@
-import { Config } from "../bombermanConfig"
-import { v4 as uuidv4 } from 'uuid';
+import { Config } from '../bombermanConfig'
+import { v4 as uuidv4 } from 'uuid'
 import enemyFrontImg from '../assets/enemy-front.png'
 import enemyFrontWalk1Img from '../assets/enemy-front-walk1.png'
 import enemyFrontWalk2Img from '../assets/enemy-front-walk2.png'
@@ -12,255 +12,264 @@ import enemyRightImg from '../assets/enemy-right.png'
 import enemyRightWalkImg from '../assets/enemy-right-walk.png'
 
 export class Enemies {
-    x: number = 0;
-    y: number = 0;
-    width: number = 32
-    height: number = 32
-    direction: string
-    pastDirection: string = 'down'
-    enemyImg: string
-    step:number = 1
-    isFirst: boolean =true;
-    id: string
+  x: number = 0
+  y: number = 0
+  width: number = 32
+  height: number = 32
+  direction: string
+  pastDirection: string = 'down'
+  enemyImg: string
+  step: number = 1
+  isFirst: boolean = true
+  id: string
 
-    maxBolcks: number
-    canvasSize: number = 510
-    numOfBox: number = 17
-    boxSize: number = this.canvasSize / this.numOfBox
-    stageMap = { grass: 0, stone: 1, wall: 2, bomb: 3, player: 10, fireH: 11, fireV: 12, fireO: 13, bombUp: 21, fireUp: 22, speedUp: 23}
+  maxBolcks: number
+  canvasSize: number = 510
+  numOfBox: number = 17
+  boxSize: number = this.canvasSize / this.numOfBox
+  stageMap = {
+    grass: 0,
+    stone: 1,
+    wall: 2,
+    bomb: 3,
+    player: 10,
+    fireH: 11,
+    fireV: 12,
+    fireO: 13,
+    bombUp: 21,
+    fireUp: 22,
+    speedUp: 23,
+  }
 
-
-    constructor(config: Config, currentStage: number[][]) {
-        this.maxBolcks = config.x;
-        this.id = uuidv4()
-        if(this.isFirst){
-            this.inititalDefinePosition(currentStage);
-        }else{
-            this.definePosition(currentStage);
-        }
-        
-        this.direction = this.changeRandomDirection();
-        this.enemyImg = enemyFrontImg;
-
-        setInterval(() => {
-            this.changeDirection(currentStage);
-        }, 300);
+  constructor(config: Config, currentStage: number[][]) {
+    this.maxBolcks = config.x
+    this.id = uuidv4()
+    if (this.isFirst) {
+      this.inititalDefinePosition(currentStage)
+    } else {
+      this.definePosition(currentStage)
     }
 
-    inititalDefinePosition(currentStage: number[][]): void{
-        const max: number = this.maxBolcks;
+    this.direction = this.changeRandomDirection()
+    this.enemyImg = enemyFrontImg
 
-        let randomNumY: number = Math.floor(Math.random() * (max - 5)) + 5;
-        let randomNumX: number = Math.floor(Math.random() * (max - 5)) + 5;
+    setInterval(() => {
+      this.changeDirection(currentStage)
+    }, 300)
+  }
 
-        while (currentStage[randomNumY][randomNumX] !== 0) {
-            randomNumX = Math.floor(Math.random() * (max - 5)) + 5;
-            randomNumY = Math.floor(Math.random() * (max - 5)) + 5;
-        }
-        this.x = this.boxSize * randomNumX
-        this.y = this.boxSize * randomNumY
-        this.isFirst = false;
+  inititalDefinePosition(currentStage: number[][]): void {
+    const max: number = this.maxBolcks
+
+    let randomNumY: number = Math.floor(Math.random() * (max - 5)) + 5
+    let randomNumX: number = Math.floor(Math.random() * (max - 5)) + 5
+
+    while (currentStage[randomNumY][randomNumX] !== 0) {
+      randomNumX = Math.floor(Math.random() * (max - 5)) + 5
+      randomNumY = Math.floor(Math.random() * (max - 5)) + 5
     }
+    this.x = this.boxSize * randomNumX
+    this.y = this.boxSize * randomNumY
+    this.isFirst = false
+  }
 
-    definePosition(currentStage: number[][]): void {
-        const max: number = this.maxBolcks;
+  definePosition(currentStage: number[][]): void {
+    const max: number = this.maxBolcks
 
-        let randomNumY: number = Math.floor(Math.random() * (max - 1)) + 1;
-        let randomNumX: number = Math.floor(Math.random() * (max - 1)) + 1;
+    let randomNumY: number = Math.floor(Math.random() * (max - 1)) + 1
+    let randomNumX: number = Math.floor(Math.random() * (max - 1)) + 1
 
-        while (currentStage[randomNumY][randomNumX] !== 0) {
-            randomNumX = Math.floor(Math.random() * (max - 1)) + 1;
-            randomNumY = Math.floor(Math.random() * (max - 1)) + 1;
-        }
-        this.x = this.boxSize * randomNumX
-        this.y = this.boxSize * randomNumY
+    while (currentStage[randomNumY][randomNumX] !== 0) {
+      randomNumX = Math.floor(Math.random() * (max - 1)) + 1
+      randomNumY = Math.floor(Math.random() * (max - 1)) + 1
     }
+    this.x = this.boxSize * randomNumX
+    this.y = this.boxSize * randomNumY
+  }
 
-    drawEnemy(canvas: CanvasRenderingContext2D | null | undefined): void {
-        const img = document.createElement('img')
-        img.src = this.changeEnemyImg()
-        canvas?.drawImage(
-            img,
-            this.x,
-            this.y,
-            this.width,
-            this.height,
-        );
+  drawEnemy(canvas: CanvasRenderingContext2D | null | undefined): void {
+    const img = document.createElement('img')
+    img.src = this.changeEnemyImg()
+    canvas?.drawImage(img, this.x, this.y, this.width, this.height)
+  }
+
+  moveEnemy(canvas: CanvasRenderingContext2D | null | undefined, currentStage: number[][], enemies: Enemies[]): void {
+    const centerX = this.x + this.width / 2
+    const centerY = this.y + this.height / 2
+    const i: number = this.getIndex(centerY)
+    const j: number = this.getIndex(centerX)
+
+    if (this.direction === 'up') {
+      this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * -1), j, -1, 'vertical', currentStage)
+    } else if (this.direction === 'down') {
+      this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * 1), j, 1, 'vertical', currentStage)
+    } else if (this.direction === 'left') {
+      this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * -1), -1, 'horizontal', currentStage)
+    } else if (this.direction === 'right') {
+      this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * 1), 1, 'horizontal', currentStage)
     }
+  }
 
-    moveEnemy(canvas: CanvasRenderingContext2D | null | undefined, currentStage: number[][], enemies: Enemies[]): void {
+  changeDirection(currentStage: number[][]): void {
+    const directions: string[] = this.checkDirections(currentStage)
+    const randomDirection: string = directions[Math.floor(Math.random() * directions.length)]
+    this.direction = randomDirection
+  }
 
-        const centerX = this.x + this.width / 2
-        const centerY = this.y + this.height / 2
-        const i: number = this.getIndex(centerY)
-        const j: number = this.getIndex(centerX)
+  checkDirections(currentStage: number[][]): string[] {
+    const i: number = this.getIndex(this.y + this.width / 2)
+    const j: number = this.getIndex(this.x + this.height / 2)
+    const up: number = currentStage[i - 1][j]
+    const down: number = currentStage[i + 1][j]
+    const left: number = currentStage[i][j - 1]
+    const right: number = currentStage[i][j + 1]
 
-        if(this.direction === 'up'){
-            this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * -1), j, -1, 'vertical', currentStage)
-        }
-        else if(this.direction === 'down'){
-            this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * 1), j, 1, 'vertical', currentStage)
-        }
-        else if(this.direction === 'left'){
-            this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * -1), -1, 'horizontal', currentStage)
-        }
-        else if(this.direction === 'right'){
-            this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * 1), 1, 'horizontal', currentStage)
-        }
+    let directions: string[] = []
+    if (up !== this.stageMap.stone && up !== this.stageMap.wall && up !== this.stageMap.bomb) {
+      directions.push('up')
     }
-
-    changeDirection(currentStage: number[][]): void{
-        const directions: string[] = this.checkDirections(currentStage)
-        const randomDirection: string = directions[Math.floor(Math.random() * directions.length)]
-        this.direction = randomDirection
+    if (down !== this.stageMap.stone && down !== this.stageMap.wall && down !== this.stageMap.bomb) {
+      directions.push('down')
     }
-
-    checkDirections(currentStage: number[][]): string[]{
-        const i: number = this.getIndex(this.y + this.width / 2)
-        const j: number = this.getIndex(this.x + this.height / 2)
-        const up: number = currentStage[i-1][j]
-        const down: number = currentStage[i+1][j]
-        const left: number = currentStage[i][j-1]
-        const right: number = currentStage[i][j+1]
-    
-        let directions: string[] = []
-        if(up !== this.stageMap.stone && up !== this.stageMap.wall && up !== this.stageMap.bomb){
-            directions.push('up')
-        }
-        if(down !== this.stageMap.stone && down !== this.stageMap.wall && down !== this.stageMap.bomb){
-            directions.push('down')
-        }
-        if(left !== this.stageMap.stone && left !== this.stageMap.wall && left !== this.stageMap.bomb){
-            directions.push('left')
-        }
-        if(right !== this.stageMap.stone && right !== this.stageMap.wall && right !== this.stageMap.bomb){
-            directions.push('right')
-        }
-        // きた方向以外も動けるとき
-        if(directions.length > 1){
-            const opposite = this.getOppositeDirection()
-            console.log("direction:", this.direction, "opp:", opposite)
-            directions = directions.filter(direction => direction !== opposite)
-        }
-        return directions
+    if (left !== this.stageMap.stone && left !== this.stageMap.wall && left !== this.stageMap.bomb) {
+      directions.push('left')
     }
-
-    getOppositeDirection(): string{
-        let opposite: string = ""
-        if(this.direction === 'up'){
-            opposite = "down"
-        } else if(this.direction === 'down'){
-            opposite = "up"
-        } else if(this.direction === 'left'){
-            opposite = "right"
-        } else if(this.direction === 'right'){
-            opposite = "left"
-        }
-        return opposite
+    if (right !== this.stageMap.stone && right !== this.stageMap.wall && right !== this.stageMap.bomb) {
+      directions.push('right')
     }
-    
-
-    getBound(moveTo: string, direction: number) : number{
-        let bound: number = 0
-        if(moveTo === 'horizontal'){
-            bound = this.x + this.step * direction
-            if(direction >= 0) bound += this.width
-        } else{
-            bound = this.y + this.step * direction
-            if(direction >= 0) bound += this.height
-        }
-        return bound
+    // きた方向以外も動けるとき
+    if (directions.length > 1) {
+      const opposite = this.getOppositeDirection()
+      directions = directions.filter((direction) => direction !== opposite)
     }
+    return directions
+  }
 
-    moveOneStep(i: number, j: number, moveTo: string, direction: number): void{
-        if(moveTo === 'horizontal'){
-            this.y = i * this.boxSize
-            this.x += this.step * direction
-        } else {
-            this.x = j * this.boxSize
-            this.y += this.step * direction
-        }
+  getOppositeDirection(): string {
+    let opposite: string = ''
+    if (this.direction === 'up') {
+      opposite = 'down'
+    } else if (this.direction === 'down') {
+      opposite = 'up'
+    } else if (this.direction === 'left') {
+      opposite = 'right'
+    } else if (this.direction === 'right') {
+      opposite = 'left'
     }
+    return opposite
+  }
 
-    getIndex(position: number): number{
-        return Math.floor(position / this.boxSize)
+  getBound(moveTo: string, direction: number): number {
+    let bound: number = 0
+    if (moveTo === 'horizontal') {
+      bound = this.x + this.step * direction
+      if (direction >= 0) bound += this.width
+    } else {
+      bound = this.y + this.step * direction
+      if (direction >= 0) bound += this.height
     }
+    return bound
+  }
 
-    changeRandomDirection(): string {
-        const Directon: string[] = ['up','down','left','right']
-        const randomNum: number = Math.floor(Math.random() * (4 - 0)) + 0;
-
-        this.pastDirection = this.direction
-        return Directon[randomNum]
+  moveOneStep(i: number, j: number, moveTo: string, direction: number): void {
+    if (moveTo === 'horizontal') {
+      this.y = i * this.boxSize
+      this.x += this.step * direction
+    } else {
+      this.x = j * this.boxSize
+      this.y += this.step * direction
     }
+  }
 
-    changeEnemyImg(): string{
-        let src: string = enemyFrontImg
-        if(this.direction === ''){
-            if(this.pastDirection === 'up') src = enemyBackImg
-            if(this.pastDirection === 'down') src = enemyFrontImg
-            else if(this.pastDirection === 'left') src = enemyLeftImg
-            else if(this.pastDirection === 'right') src = enemyRightImg
-        } else{
-            if(this.direction === 'down'){
-                src = this.enemyImg === enemyFrontWalk1Img ? enemyFrontWalk2Img : enemyFrontWalk1Img
-            }
-            else if(this.direction === 'up'){
-                src = this.enemyImg === enemyBackWalk1Img ? enemyBackWalk2Img : enemyBackWalk1Img
-            }
-            else if(this.direction === 'left'){
-                src = this.enemyImg === enemyLeftImg ? enemyLeftWalkImg : enemyLeftImg
-            }
-            else if(this.direction === 'right'){
-                src = this.enemyImg === enemyRightImg ? enemyRightWalkImg : enemyRightImg
-            }
-        }
-        this.enemyImg = src
-        return src
+  getIndex(position: number): number {
+    return Math.floor(position / this.boxSize)
+  }
+
+  changeRandomDirection(): string {
+    const Directon: string[] = ['up', 'down', 'left', 'right']
+    const randomNum: number = Math.floor(Math.random() * (4 - 0)) + 0
+
+    this.pastDirection = this.direction
+    return Directon[randomNum]
+  }
+
+  changeEnemyImg(): string {
+    let src: string = enemyFrontImg
+    if (this.direction === '') {
+      if (this.pastDirection === 'up') src = enemyBackImg
+      if (this.pastDirection === 'down') src = enemyFrontImg
+      else if (this.pastDirection === 'left') src = enemyLeftImg
+      else if (this.pastDirection === 'right') src = enemyRightImg
+    } else {
+      if (this.direction === 'down') {
+        src = this.enemyImg === enemyFrontWalk1Img ? enemyFrontWalk2Img : enemyFrontWalk1Img
+      } else if (this.direction === 'up') {
+        src = this.enemyImg === enemyBackWalk1Img ? enemyBackWalk2Img : enemyBackWalk1Img
+      } else if (this.direction === 'left') {
+        src = this.enemyImg === enemyLeftImg ? enemyLeftWalkImg : enemyLeftImg
+      } else if (this.direction === 'right') {
+        src = this.enemyImg === enemyRightImg ? enemyRightWalkImg : enemyRightImg
+      }
     }
+    this.enemyImg = src
+    return src
+  }
 
-    checkEnemyMove(i: number, j: number, nextI: number, nextJ: number, direction: number, moveTo: string,  currentStage: number[][]): void{
-        // if(this.isOnTheBomb(i, j, direction, moveTo, currentStage)){
-        //     this.moveOneStep(i, j, moveTo, direction)
-        //     return
-        // }
-        const bound = this.getBound(moveTo, direction)
-        // Playerまるパクり
-        // if(this.hitExplosion(i, j, nextI, nextJ, bound, moveTo, currentStage)){
-        //     enemies.filter(enemy -> id)
-        // 
+  checkEnemyMove(
+    i: number,
+    j: number,
+    nextI: number,
+    nextJ: number,
+    direction: number,
+    moveTo: string,
+    currentStage: number[][]
+  ): void {
+    // if(this.isOnTheBomb(i, j, direction, moveTo, currentStage)){
+    //     this.moveOneStep(i, j, moveTo, direction)
+    //     return
+    // }
+    const bound = this.getBound(moveTo, direction)
+    // Playerまるパクり
+    // if(this.hitExplosion(i, j, nextI, nextJ, bound, moveTo, currentStage)){
+    //     enemies.filter(enemy -> id)
+    //
 
-        // hitPlayer(){
-            // player.isAlive = false
-        //}
-        if(!this.canMove(i, j, nextI, nextJ, bound, moveTo, currentStage)) return
-        
-        else if(nextI !== i || nextJ !== j){
-            // this.changeDirection(currentStage)
-            // currentStageのplayerの位置を更新
-            // if(currentStage[nextI][nextJ] >= this.stageMap.bombUp){
-            //     this.getItem(currentStage[nextI][nextJ])
-            // }
-            // currentStage[i][j] = this.stageMap.grass
-            // currentStage[nextI][nextJ] = this.stageMap.player
-        }
-        this.moveOneStep(i, j, moveTo, direction)
+    // hitPlayer(){
+    // player.isAlive = false
+    // }
+    if (!this.canMove(i, j, nextI, nextJ, bound, moveTo, currentStage)) return
+    else if (nextI !== i || nextJ !== j) {
+      // this.changeDirection(currentStage)
+      // currentStageのplayerの位置を更新
+      // if(currentStage[nextI][nextJ] >= this.stageMap.bombUp){
+      //     this.getItem(currentStage[nextI][nextJ])
+      // }
+      // currentStage[i][j] = this.stageMap.grass
+      // currentStage[nextI][nextJ] = this.stageMap.player
     }
+    this.moveOneStep(i, j, moveTo, direction)
+  }
 
-    canMove(i: number, j: number, nextI: number, nextJ: number, bound: number, moveTo:string, currentStage: number[][]): boolean{
-        if(moveTo === 'horizontal'){
-            // itemのとき
-            if(currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp){
-                return true
-            }
-            return currentStage[nextI][nextJ] % 10 === 0 && currentStage[i][this.getIndex(bound)] % 10 === 0
-        } else {
-            if(currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp){
-                return true
-            }
-            return currentStage[nextI][nextJ] % 10 === 0 && currentStage[this.getIndex(bound)][j] % 10 === 0
-        }
+  canMove(
+    i: number,
+    j: number,
+    nextI: number,
+    nextJ: number,
+    bound: number,
+    moveTo: string,
+    currentStage: number[][]
+  ): boolean {
+    if (moveTo === 'horizontal') {
+      // itemのとき
+      if (currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp) {
+        return true
+      }
+      return currentStage[nextI][nextJ] % 10 === 0 && currentStage[i][this.getIndex(bound)] % 10 === 0
+    } else {
+      if (currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp) {
+        return true
+      }
+      return currentStage[nextI][nextJ] % 10 === 0 && currentStage[this.getIndex(bound)][j] % 10 === 0
     }
-
+  }
 }
-

--- a/client/src/pages/MultiGame.tsx
+++ b/client/src/pages/MultiGame.tsx
@@ -32,11 +32,13 @@ const MultiGame: React.FC = () => {
   const onlineCanvas = useRef<HTMLCanvasElement>(null)
   const [canvasContext, setCavnasContext] = useState<CanvasRenderingContext2D | null | undefined>(null)
   const [stopPlayer, changeDirection] = usePlayerMove()
+  const [drawPlayersOnCanvas] = useDrawPlayers()
 
-  const drawPlayers = (plys: OnlinePlayer[]): void => {
+  const drawPlayers = async (plys: OnlinePlayer[]): Promise<void> => {
     if (canvasContext != null) {
-      useDrawPlayers(plys, canvasContext, STAGESIZE)
+      await drawPlayersOnCanvas(plys, canvasContext, STAGESIZE)
     }
+    return await new Promise((resolve) => resolve())
   }
 
   const addKeyEvents = (): void => {
@@ -67,8 +69,9 @@ const MultiGame: React.FC = () => {
     })
   }
 
-  useInterval(() => {
+  useInterval(async () => {
     if (players != null && myPlayer != null && players.length > 0) {
+      await drawPlayers(players)
       setMyPlayer({ ...myPlayer, direction: lastDirection })
       socket?.emit('player_interval', {
         player: { ...myPlayer, direction: lastDirection },
@@ -93,7 +96,7 @@ const MultiGame: React.FC = () => {
       setPlayers(data.players)
       setMyPlayer(data.players.filter((player) => player.socketId === socket.id)[0])
       setStage(data.stage)
-      drawPlayers(data.players)
+      // drawPlayers(data.players)
     })
     socket?.on('send_game_result', (data: DeadPlayer[]) => {
       interval = null

--- a/client/src/pages/MultiGame.tsx
+++ b/client/src/pages/MultiGame.tsx
@@ -70,13 +70,15 @@ const MultiGame: React.FC = () => {
   }
 
   useInterval(async () => {
-    if (players != null && myPlayer != null && players.length > 0) {
+    if (players != null && players.length > 0) {
       await drawPlayers(players)
-      setMyPlayer({ ...myPlayer, direction: lastDirection })
-      socket?.emit('player_interval', {
-        player: { ...myPlayer, direction: lastDirection },
-        roomName,
-      })
+      if (myPlayer != null) {
+        setMyPlayer({ ...myPlayer, direction: lastDirection })
+        socket?.emit('player_interval', {
+          player: { ...myPlayer, direction: lastDirection },
+          roomName,
+        })
+      }
     }
   }, interval)
 
@@ -89,14 +91,13 @@ const MultiGame: React.FC = () => {
       const context = onlineCanvas.current
       setCavnasContext(context?.getContext('2d'))
     }
-  }, [onlineCanvas])
+  }, [onlineCanvas, canvasContext])
 
   useEffect(() => {
     socket?.on('send_game_status', (data: { players: OnlinePlayer[]; stage: number[][] }) => {
       setPlayers(data.players)
       setMyPlayer(data.players.filter((player) => player.socketId === socket.id)[0])
       setStage(data.stage)
-      // drawPlayers(data.players)
     })
     socket?.on('send_game_result', (data: DeadPlayer[]) => {
       interval = null

--- a/server/player.ts
+++ b/server/player.ts
@@ -19,6 +19,8 @@ export class Player {
   y: number;
   size: number = 30;
   direction: string = "stay";
+  pastDirection: string = "down";
+  imageType: number = 1;
   speed: number = 5;
   numOfBombs: number = 1;
   bombPower: number = 1;
@@ -63,6 +65,9 @@ export class Player {
     if (this.collideWithItem(board)) {
       this.getItem(board);
     }
+    // 表示する画像を変えるため
+    if (this.direction !== "stay") this.pastDirection = this.direction;
+    this.imageType = this.imageType === 1 ? 2 : 1;
   }
 
   // indexに応じて滑らかな動き


### PR DESCRIPTION
### 関連しているIssue / 目的
#50
### 達成条件
プレイヤーが歩く動きを再現する
各プレイヤーを区別できるようにする

### 実装の概要 / このPRの対応範囲
プレイヤーの歩きはオフラインのほうと同じで画像の種類を加えることで実装。
プレイヤーの区別はプレイヤーの頭上にプレイヤー名を表示することで実装。

画像を変更するのに非同期関数を使っています。
