### PR TITLE
エネミーが爆発した時とプレイヤーに当たった時の処理を追加

### DIFF
--- a/client/src/atom/Atom.ts
+++ b/client/src/atom/Atom.ts
@@ -11,11 +11,16 @@ export const currentStageAtom: PrimitiveAtom<number[][]> = atom(currentStage.get
 
 export const playerAtom = atom<Player>(new Player('player1'))
 // export const enemiesAtom = atom<Enemies>(new Enemies(config1, currentStage.getBoard()))
+
+
+
 export const enemiesAtom: PrimitiveAtom<Enemies[]>= atom([
     new Enemies(config1, currentStage.getBoard()),
     new Enemies(config1, currentStage.getBoard()),
     new Enemies(config1, currentStage.getBoard())
 ])
+
+
 
 // online game
 export const socketAtom = atom<any>(null)

--- a/client/src/models/Enemies.tsx
+++ b/client/src/models/Enemies.tsx
@@ -10,35 +10,39 @@ import enemyLeftImg from '../assets/enemy-left.png'
 import enemyLeftWalkImg from '../assets/enemy-left-walk.png'
 import enemyRightImg from '../assets/enemy-right.png'
 import enemyRightWalkImg from '../assets/enemy-right-walk.png'
+import { textSpanIntersectsWith } from "typescript";
+import { Player } from "./Player";
 
 export class Enemies {
+
+    id: string;
+    isAlive: boolean = true;
     x: number = 0;
     y: number = 0;
     width: number = 32
     height: number = 32
     direction: string
     pastDirection: string = 'down'
+    step: number = 1
+    isFirst: boolean = true;
     enemyImg: string
-    step:number = 1
-    isFirst: boolean =true;
-    id: string
 
     maxBolcks: number
     canvasSize: number = 510
     numOfBox: number = 17
     boxSize: number = this.canvasSize / this.numOfBox
-    stageMap = { grass: 0, stone: 1, wall: 2, bomb: 3, player: 10, fireH: 11, fireV: 12, fireO: 13, bombUp: 21, fireUp: 22, speedUp: 23}
+    stageMap = { grass: 0, stone: 1, wall: 2, bomb: 3, player: 10, fireH: 11, fireV: 12, fireO: 13, bombUp: 21, fireUp: 22, speedUp: 23 }
 
 
     constructor(config: Config, currentStage: number[][]) {
         this.maxBolcks = config.x;
         this.id = uuidv4()
-        if(this.isFirst){
+        if (this.isFirst) {
             this.inititalDefinePosition(currentStage);
-        }else{
+        } else {
             this.definePosition(currentStage);
         }
-        
+
         this.direction = this.changeRandomDirection();
         this.enemyImg = enemyFrontImg;
 
@@ -47,7 +51,7 @@ export class Enemies {
         }, 300);
     }
 
-    inititalDefinePosition(currentStage: number[][]): void{
+    inititalDefinePosition(currentStage: number[][]): void {
         const max: number = this.maxBolcks;
 
         let randomNumY: number = Math.floor(Math.random() * (max - 5)) + 5;
@@ -88,92 +92,91 @@ export class Enemies {
         );
     }
 
-    moveEnemy(canvas: CanvasRenderingContext2D | null | undefined, currentStage: number[][], enemies: Enemies[]): void {
+    moveEnemy(canvas: CanvasRenderingContext2D | null | undefined, currentStage: number[][], player: Player): void {
 
         const centerX = this.x + this.width / 2
         const centerY = this.y + this.height / 2
         const i: number = this.getIndex(centerY)
         const j: number = this.getIndex(centerX)
 
-        if(this.direction === 'up'){
-            this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * -1), j, -1, 'vertical', currentStage)
+        if (this.direction === 'up') {
+            this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * -1), j, -1, 'vertical', currentStage, player)
         }
-        else if(this.direction === 'down'){
-            this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * 1), j, 1, 'vertical', currentStage)
+        else if (this.direction === 'down') {
+            this.checkEnemyMove(i, j, this.getIndex(centerY + this.step * 1), j, 1, 'vertical', currentStage, player)
         }
-        else if(this.direction === 'left'){
-            this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * -1), -1, 'horizontal', currentStage)
+        else if (this.direction === 'left') {
+            this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * -1), -1, 'horizontal', currentStage, player)
         }
-        else if(this.direction === 'right'){
-            this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * 1), 1, 'horizontal', currentStage)
+        else if (this.direction === 'right') {
+            this.checkEnemyMove(i, j, i, this.getIndex(centerX + this.step * 1), 1, 'horizontal', currentStage, player)
         }
     }
 
-    changeDirection(currentStage: number[][]): void{
+    changeDirection(currentStage: number[][]): void {
         const directions: string[] = this.checkDirections(currentStage)
         const randomDirection: string = directions[Math.floor(Math.random() * directions.length)]
         this.direction = randomDirection
     }
 
-    checkDirections(currentStage: number[][]): string[]{
+    checkDirections(currentStage: number[][]): string[] {
         const i: number = this.getIndex(this.y + this.width / 2)
         const j: number = this.getIndex(this.x + this.height / 2)
-        const up: number = currentStage[i-1][j]
-        const down: number = currentStage[i+1][j]
-        const left: number = currentStage[i][j-1]
-        const right: number = currentStage[i][j+1]
-    
+        const up: number = currentStage[i - 1][j]
+        const down: number = currentStage[i + 1][j]
+        const left: number = currentStage[i][j - 1]
+        const right: number = currentStage[i][j + 1]
+
         let directions: string[] = []
-        if(up !== this.stageMap.stone && up !== this.stageMap.wall && up !== this.stageMap.bomb){
+        if (up !== this.stageMap.stone && up !== this.stageMap.wall && up !== this.stageMap.bomb) {
             directions.push('up')
         }
-        if(down !== this.stageMap.stone && down !== this.stageMap.wall && down !== this.stageMap.bomb){
+        if (down !== this.stageMap.stone && down !== this.stageMap.wall && down !== this.stageMap.bomb) {
             directions.push('down')
         }
-        if(left !== this.stageMap.stone && left !== this.stageMap.wall && left !== this.stageMap.bomb){
+        if (left !== this.stageMap.stone && left !== this.stageMap.wall && left !== this.stageMap.bomb) {
             directions.push('left')
         }
-        if(right !== this.stageMap.stone && right !== this.stageMap.wall && right !== this.stageMap.bomb){
+        if (right !== this.stageMap.stone && right !== this.stageMap.wall && right !== this.stageMap.bomb) {
             directions.push('right')
         }
         // きた方向以外も動けるとき
-        if(directions.length > 1){
+        if (directions.length > 1) {
             const opposite = this.getOppositeDirection()
-            console.log("direction:", this.direction, "opp:", opposite)
             directions = directions.filter(direction => direction !== opposite)
         }
         return directions
     }
 
-    getOppositeDirection(): string{
+    getOppositeDirection(): string {
         let opposite: string = ""
-        if(this.direction === 'up'){
+        if (this.direction === 'up') {
             opposite = "down"
-        } else if(this.direction === 'down'){
+        } else if (this.direction === 'down') {
             opposite = "up"
-        } else if(this.direction === 'left'){
+        } else if (this.direction === 'left') {
             opposite = "right"
-        } else if(this.direction === 'right'){
+        } else if (this.direction === 'right') {
             opposite = "left"
         }
         return opposite
     }
-    
 
-    getBound(moveTo: string, direction: number) : number{
+
+    getBound(moveTo: string, direction: number): number {
         let bound: number = 0
-        if(moveTo === 'horizontal'){
+        if (moveTo === 'horizontal') {
             bound = this.x + this.step * direction
-            if(direction >= 0) bound += this.width
-        } else{
+            if (direction >= 0) bound += this.width
+        } else {
             bound = this.y + this.step * direction
-            if(direction >= 0) bound += this.height
+            if (direction >= 0) bound += this.height
         }
         return bound
     }
 
-    moveOneStep(i: number, j: number, moveTo: string, direction: number): void{
-        if(moveTo === 'horizontal'){
+    moveOneStep(i: number, j: number, moveTo: string, direction: number): void {
+        if (moveTo === 'horizontal') {
             this.y = i * this.boxSize
             this.x += this.step * direction
         } else {
@@ -182,36 +185,36 @@ export class Enemies {
         }
     }
 
-    getIndex(position: number): number{
+    getIndex(position: number): number {
         return Math.floor(position / this.boxSize)
     }
 
     changeRandomDirection(): string {
-        const Directon: string[] = ['up','down','left','right']
+        const Directon: string[] = ['up', 'down', 'left', 'right']
         const randomNum: number = Math.floor(Math.random() * (4 - 0)) + 0;
 
         this.pastDirection = this.direction
         return Directon[randomNum]
     }
 
-    changeEnemyImg(): string{
+    changeEnemyImg(): string {
         let src: string = enemyFrontImg
-        if(this.direction === ''){
-            if(this.pastDirection === 'up') src = enemyBackImg
-            if(this.pastDirection === 'down') src = enemyFrontImg
-            else if(this.pastDirection === 'left') src = enemyLeftImg
-            else if(this.pastDirection === 'right') src = enemyRightImg
-        } else{
-            if(this.direction === 'down'){
+        if (this.direction === '') {
+            if (this.pastDirection === 'up') src = enemyBackImg
+            if (this.pastDirection === 'down') src = enemyFrontImg
+            else if (this.pastDirection === 'left') src = enemyLeftImg
+            else if (this.pastDirection === 'right') src = enemyRightImg
+        } else {
+            if (this.direction === 'down') {
                 src = this.enemyImg === enemyFrontWalk1Img ? enemyFrontWalk2Img : enemyFrontWalk1Img
             }
-            else if(this.direction === 'up'){
+            else if (this.direction === 'up') {
                 src = this.enemyImg === enemyBackWalk1Img ? enemyBackWalk2Img : enemyBackWalk1Img
             }
-            else if(this.direction === 'left'){
+            else if (this.direction === 'left') {
                 src = this.enemyImg === enemyLeftImg ? enemyLeftWalkImg : enemyLeftImg
             }
-            else if(this.direction === 'right'){
+            else if (this.direction === 'right') {
                 src = this.enemyImg === enemyRightImg ? enemyRightWalkImg : enemyRightImg
             }
         }
@@ -219,23 +222,23 @@ export class Enemies {
         return src
     }
 
-    checkEnemyMove(i: number, j: number, nextI: number, nextJ: number, direction: number, moveTo: string,  currentStage: number[][]): void{
-        // if(this.isOnTheBomb(i, j, direction, moveTo, currentStage)){
-        //     this.moveOneStep(i, j, moveTo, direction)
-        //     return
-        // }
+    checkEnemyMove(i: number, j: number, nextI: number, nextJ: number, direction: number, moveTo: string, currentStage: number[][], player: Player): void {
         const bound = this.getBound(moveTo, direction)
-        // Playerまるパクり
-        // if(this.hitExplosion(i, j, nextI, nextJ, bound, moveTo, currentStage)){
-        //     enemies.filter(enemy -> id)
-        // 
 
-        // hitPlayer(){
-            // player.isAlive = false
-        //}
-        if(!this.canMove(i, j, nextI, nextJ, bound, moveTo, currentStage)) return
-        
-        else if(nextI !== i || nextJ !== j){
+        // エネミーと爆弾が当たった時の処理
+        if (this.hitExplosion(i, j, nextI, nextJ, bound, moveTo, currentStage)) {
+            this.isAlive = false
+        }
+
+        // エネミーとプレイヤーが当たった時の処理
+        if (this.hitPlayer(i, j, nextI, nextJ, bound, moveTo, currentStage)) {
+            console.log('koko')
+            player.isAlive = false
+        }
+
+        if (!this.canMove(i, j, nextI, nextJ, bound, moveTo, currentStage)) return
+
+        else if (nextI !== i || nextJ !== j) {
             // this.changeDirection(currentStage)
             // currentStageのplayerの位置を更新
             // if(currentStage[nextI][nextJ] >= this.stageMap.bombUp){
@@ -247,15 +250,50 @@ export class Enemies {
         this.moveOneStep(i, j, moveTo, direction)
     }
 
-    canMove(i: number, j: number, nextI: number, nextJ: number, bound: number, moveTo:string, currentStage: number[][]): boolean{
+    hitExplosion(i: number, j: number, nextI: number, nextJ: number, bound: number, moveTo: string, currentStage: number[][]): boolean {
+        if (currentStage[nextI][nextJ] >= this.stageMap.bombUp || currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp) {
+            return false
+        }
+        if (moveTo === 'horizontal') {
+            if (currentStage[nextI][nextJ] >= this.stageMap.bombUp || currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp) {
+                return false
+            } else {
+                return currentStage[nextI][nextJ] > this.stageMap.player || currentStage[i][this.getIndex(bound)] > this.stageMap.player
+            }
+        } else {
+            if (currentStage[nextI][nextJ] >= this.stageMap.bombUp || currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp) {
+                return false
+            } else {
+                return currentStage[nextI][nextJ] > this.stageMap.player || currentStage[this.getIndex(bound)][j] > this.stageMap.player
+            }
+        }
+    }
+
+    hitPlayer(i: number, j: number, nextI: number, nextJ: number, bound: number, moveTo: string, currentStage: number[][]): boolean {
         if(moveTo === 'horizontal'){
+            if (currentStage[nextI][nextJ] === this.stageMap.player || currentStage[i][this.getIndex(bound)] === this.stageMap.player) {
+                return true
+            } else{
+                return false
+            }
+        } else {
+            if (currentStage[nextI][nextJ] === this.stageMap.player || currentStage[this.getIndex(bound)][j] === this.stageMap.player) {
+                return true
+            } else{
+                return false
+            }
+        }
+    }
+
+    canMove(i: number, j: number, nextI: number, nextJ: number, bound: number, moveTo: string, currentStage: number[][]): boolean {
+        if (moveTo === 'horizontal') {
             // itemのとき
-            if(currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp){
+            if (currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp) {
                 return true
             }
             return currentStage[nextI][nextJ] % 10 === 0 && currentStage[i][this.getIndex(bound)] % 10 === 0
         } else {
-            if(currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp){
+            if (currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp) {
                 return true
             }
             return currentStage[nextI][nextJ] % 10 === 0 && currentStage[this.getIndex(bound)][j] % 10 === 0

--- a/client/src/models/Enemies.tsx
+++ b/client/src/models/Enemies.tsx
@@ -232,7 +232,6 @@ export class Enemies {
 
         // エネミーとプレイヤーが当たった時の処理
         if (this.hitPlayer(i, j, nextI, nextJ, bound, moveTo, currentStage)) {
-            console.log('koko')
             player.isAlive = false
         }
 

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -15,6 +15,10 @@ import { currentStageAtom, playerAtom, enemiesAtom } from '../atom/Atom'
 import { GameRecordGateWay } from '../dataaccess/gameRecordGateway';
 import { GameRecord } from '../dataaccess/recordType';
 
+
+
+
+
 const Game: React.FC = () => {
   const [currentStage] = useAtom(currentStageAtom)
   const gameCanvasRef = useRef<HTMLCanvasElement>(null)
@@ -22,39 +26,39 @@ const Game: React.FC = () => {
   const [player] = useAtom(playerAtom)
   const [gameTime, setGameTime] = useState<number>(0)
   const navigate = useNavigate()
-  const [enemies] = useAtom(enemiesAtom)
+  let [enemies] = useAtom(enemiesAtom)
   const gameRecordGateway = new GameRecordGateWay();
- 
+
   useEffect(() => {
-    if(gameCanvasRef != null){
+    if (gameCanvasRef != null) {
       const a = gameCanvasRef.current?.getContext('2d')
       setCavnasContext(a)
       player.draw(canvasContext)
-      
+
     }
     addKeyEvents()
     return () => removeKeyEvents()
-    
-    
-  },[canvasContext])
+
+
+  }, [canvasContext])
 
   useInterval(() => {
     setGameTime(gameTime + 0.01)
     player?.move(canvasContext, currentStage)
     player?.drawBombs(canvasContext)
-    for(let i: number = 0; i < enemies.length; i++){
-      enemies[i].moveEnemy(canvasContext, currentStage, enemies);
+    enemies = enemies.filter(enemy => enemy.isAlive)
+    for (let i: number = 0; i < enemies.length; i++) {
+      // if(enemies[i].isAlive){
+      enemies[i].moveEnemy(canvasContext, currentStage, player);
       enemies[i].drawEnemy(canvasContext);
+      // }
     }
-    // enemies[0]?.moveEnemy(canvasContext, currentStage)
-    // enemies[1]?.moveEnemy(canvasContext, currentStage)
-    // enemies[2]?.moveEnemy(canvasContext, currentStage)
-    if(!player.isAlive){
+    if (!player.isAlive) {
       showResult().catch(() => alert("kkkk"));
     }
   }, player.isAlive ? 10 : null)
 
-  const addKeyEvents = (): void => { 
+  const addKeyEvents = (): void => {
     addEventListener('keydown', playerAction)
     addEventListener('keyup', stopPlayer)
   }
@@ -78,11 +82,13 @@ const Game: React.FC = () => {
 
   const showResult = async (): Promise<void> => {
     setTimeout(() => {
-      navigate('/result', {state: {
-        name: player.name,
-        score: Math.random() * (200 -100) + 100,
-        alivedTime: gameTime,
-      }})
+      navigate('/result', {
+        state: {
+          name: player.name,
+          score: Math.random() * (200 - 100) + 100,
+          alivedTime: gameTime,
+        }
+      })
     }, 1000)
     gameRecordGateway.postGameRecord(await getCurrntRecord()).catch(() => alert("ERORR"));
   }
@@ -110,24 +116,24 @@ const Game: React.FC = () => {
         </div>
       </div>
 
-      <div className=' mx-auto bg-white mt-12 flex' style={{height: '510px', width: '510px'}}>
+      <div className=' mx-auto bg-white mt-12 flex' style={{ height: '510px', width: '510px' }}>
         <table className='h-full w-full'>
-          {currentStage.map(row => 
+          {currentStage.map(row =>
             <tr className={`h-1/${currentStage.length} w-full`} key={row[0]}>
-              {row.map(box => 
+              {row.map(box =>
                 <>
-                {
-                // grass:0, player:10,  bomb:3
-                 box === 0 || box === 10 || box === 3 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${grassImg})`}}></td>:
-                 box === 1 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${stoneImg})`}}></td>:
-                 box === 2 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${wallImg})`}}></td>:
-                 box === 11 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${horizontalFireImg})`}}></td>:
-                 box === 12 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${verticalFireImg})`}}></td>:
-                 box === 13 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${fireOriginImg})`}}></td>:
-                 box === 21 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${bombUpImg})`}}></td>:
-                 box === 22 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${fireUpImg})`}}></td>:
-                 box === 23 ? <td className={`w-1/${row.length}`} key={box} style={{backgroundImage:`url(${speedUpImg})`}}></td>: null
-                }
+                  {
+                    // grass:0, player:10,  bomb:3
+                    box === 0 || box === 10 || box === 3 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${grassImg})` }}></td> :
+                    box === 1 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${stoneImg})` }}></td> :
+                    box === 2 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${wallImg})` }}></td> :
+                    box === 11 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${horizontalFireImg})` }}></td> :
+                    box === 12 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${verticalFireImg})` }}></td> :
+                    box === 13 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${fireOriginImg})` }}></td> :
+                    box === 21 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${bombUpImg})` }}></td> :
+                    box === 22 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${fireUpImg})` }}></td> :
+                    box === 23 ? <td className={`w-1/${row.length}`} key={box} style={{ backgroundImage: `url(${speedUpImg})` }}></td> : null
+                  }
                 </>
               )}
             </tr>


### PR DESCRIPTION
### 関連しているIssue / 目的
#16　エネミーの当たり判定
エネミーが爆弾の爆風に当たった時とプレイヤーに当たった時の処理を追加しました。

### 達成条件

1. エネミーが爆弾の爆風に当たったときに、そのエネミーが消えること
2. エネミーとプレイヤーが当たっときに、ゲームオーバーになること

### 実装の概要 / このPRの対応範囲

1. エネミーが爆弾の爆風に当たったときに、そのエネミーが消えること
　エネミーの位置と爆弾の爆風が同じ位置またはエネミーの移動先と爆弾の爆風が同じ位置になったときに、エネミーリストからエネミーを削除し、爆風に当たったエネミーが画面から表示されなくなる。
　
2. エネミーの位置とプレイヤーの位置が同じ位置またはエネミーの移動先とプレイヤーの位置が同じ位置になったときに、プレイヤーのisAliveをfalseに変更する

### 重点的にレビューして欲しいところ

1. Enemies.tsxでは、エネミーにもisAliveを持たせて爆風に当たった時に、Falseに変更する。Game.tsxでは、エネミーのisAliveがTrueのエネミーのみを残すようにエネミーリストを更新し、エネミーリストに残っている（isAliveがTrue）エネミーを画面に表示させるようにしている。このロジックで実現させているが、もっと良い方法があれば教えて欲しい。

2. みんなで参考にしたゲームではプレイヤーに体力があり、エネミーに当たったら、体力が削られていた。体力が０になったらゲームオーバーみたいなゲーム性だったが、今回は、エネミーとプレイヤーが当たったら、即死するようになっているが、これで良いか全員の認識を合わせておきたい。（参考にしたゲームに準拠するようになった場合、プレイヤーに体力のパラメータを持たせるのと、その体力を画面上に表示させる必要がある。）
 
### 不安に思っていること

- 敵とプレイヤーとの当たり判定が少し厳しいかもしれないです（プレイヤーがすぐ死ぬ）。もう少し判定を緩くしてもいいかもしれないです。

- １度プレイヤーのゲームオーバーになり、ゲームをリスタートさせるとエネミーが発生しなくなるので、そこを直していく予定。

### その他情報（スクリーンショット等）
