### PR TITLE
オンラインゲームのバグをいくつか修正

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,8 +11,8 @@ import Lobby from './pages/Lobby'
 import MultiGame from './pages/MultiGame'
 import MultiResult from './pages/MultiResult'
 
-// const CONNECTION_PORT = 'localhost:3001'
-const CONNECTION_PORT = 'https://bomberman-server-2023.an.r.appspot.com'
+const CONNECTION_PORT = 'localhost:3001'
+// const CONNECTION_PORT = 'https://bomberman-server-2023.an.r.appspot.com'
 
 const App: React.FC = () => {
   const [socket, setSocket] = useAtom(socketAtom)

--- a/client/src/hooks/useDrawPlayers.ts
+++ b/client/src/hooks/useDrawPlayers.ts
@@ -52,7 +52,6 @@ const useDrawPlayers = (): [
       const player = players[i]
       await changePlayerImg(player).then((src) => {
         img.src = src
-        console.log(src)
       })
       if (player.isAlive) {
         context.drawImage(img, player.x, player.y, player.size, player.size)

--- a/client/src/pages/MultiResult.tsx
+++ b/client/src/pages/MultiResult.tsx
@@ -24,7 +24,7 @@ const MultiResult: React.FC = () => {
     navigate('/')
   }
 
-  const sortByDeathTime = (a: DeadPlayer, b: DeadPlayer): number => {
+  const sortDeadPlayers = (a: DeadPlayer, b: DeadPlayer): number => {
     if (a.deathTime > b.deathTime) {
       return -1
     } else {
@@ -33,9 +33,8 @@ const MultiResult: React.FC = () => {
   }
 
   useEffect(() => {
-    console.log(location.state.data)
-    setDeadPlayers(location.state.data.sort(sortByDeathTime))
-  }, [])
+    setDeadPlayers(location.state.data.sort(sortDeadPlayers))
+  })
 
   return (
     <div className="flex justify-center items-center w-full h-screen">

--- a/server/bomb.ts
+++ b/server/bomb.ts
@@ -88,13 +88,14 @@ export class Bomb {
     let random = Math.random();
     if (random > 0.5) {
       random = Math.random();
-      if (random > 0.6) {
+      if (random > 0.7) {
         board[i][j] = Stage.stageValues.bombUp;
-      } else if (random > 0.2) {
+      } else if (random > 0.4) {
         board[i][j] = Stage.stageValues.fireUp;
-      } else {
+      } else if (random > 0.2) {
         board[i][j] = Stage.stageValues.speedUp;
       }
+      // bombDown 1.5-2.0, fireDown 1.0-1.5, speedDown 0.0-1.0
     }
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,7 +29,8 @@ export const rooms = [
 app.use(cors());
 app.use(express.json());
 
-const server = app.listen(process.env.PORT || 8080, () => {
+// const server = app.listen(process.env.PORT || 8080, () => {
+const server = app.listen("3001", () => {
   console.log("Server is Running");
 });
 

--- a/server/player.ts
+++ b/server/player.ts
@@ -127,7 +127,8 @@ export class Player {
     return (
       stageValue === Stage.stageValues.stone ||
       stageValue === Stage.stageValues.wall ||
-      (stageValue === Stage.stageValues.bomb && !this.isOnTheBomb(board))
+      stageValue === Stage.stageValues.bomb
+      //&& !this.isOnTheBomb(board))
     );
   }
 
@@ -154,24 +155,24 @@ export class Player {
     );
   }
 
-  isOnTheBomb(board: number[][]): boolean {
-    const playerIndex: Index = new Index();
-    playerIndex.i = Math.floor((this.y + this.size / 2) / Stage.boxSize);
-    playerIndex.j = Math.floor((this.x + this.size / 2) / Stage.boxSize);
+  // isOnTheBomb(board: number[][]): boolean {
+  //   const playerIndex: Index = new Index();
+  //   playerIndex.i = Math.floor((this.y + this.size / 2) / Stage.boxSize);
+  //   playerIndex.j = Math.floor((this.x + this.size / 2) / Stage.boxSize);
 
-    const top = Math.floor(this.y / Stage.boxSize);
-    const bottom = Math.floor((this.y + this.size) / Stage.boxSize);
-    const left = Math.floor(this.x / Stage.boxSize);
-    const right = Math.floor((this.x + this.size) / Stage.boxSize);
+  //   const top = Math.floor(this.y / Stage.boxSize);
+  //   const bottom = Math.floor((this.y + this.size) / Stage.boxSize);
+  //   const left = Math.floor(this.x / Stage.boxSize);
+  //   const right = Math.floor((this.x + this.size) / Stage.boxSize);
 
-    const bomb = Stage.stageValues.bomb;
-    return (
-      board[top][playerIndex.j] === bomb ||
-      board[bottom][playerIndex.j] === bomb ||
-      board[playerIndex.i][left] === bomb ||
-      board[playerIndex.i][right] === bomb
-    );
-  }
+  //   const bomb = Stage.stageValues.bomb;
+  //   return (
+  //     board[top][playerIndex.j] === bomb ||
+  //     board[bottom][playerIndex.j] === bomb ||
+  //     board[playerIndex.i][left] === bomb ||
+  //     board[playerIndex.i][right] === bomb
+  //   );
+  // }
 
   hitExplosion(board: number[][]): boolean {
     const playerIndex: Index = new Index();

--- a/server/room.ts
+++ b/server/room.ts
@@ -43,11 +43,14 @@ export class Room {
 
   // dead
   removePlayer(player: Player): void {
+    let deathTime = (new Date().getTime() - this.gameStartTime) / 1000;
     this.players = this.players.filter((p) => p.playerId !== player.playerId);
+    if (this.players.length === 0)
+      deathTime = (new Date().getTime() - this.gameStartTime) / 100;
     this.deadPlayers.push({
       name: player.name,
       playerId: player.playerId,
-      deathTime: (new Date().getTime() - this.gameStartTime) / 1000,
+      deathTime,
       killedBy: player.killedBy,
     });
   }

--- a/server/stage.ts
+++ b/server/stage.ts
@@ -11,7 +11,7 @@ export class Stage {
   static numOfRow: number = 17;
   static size: number = 510;
   static boxSize: number = Stage.size / Stage.numOfRow;
-  static numOfBlocks: number = 30;
+  static numOfBlocks: number = 70;
   static stageValues: StageMap = {
     ground: 0,
     stone: 1,


### PR DESCRIPTION
### 関連しているIssue / 目的
#56 
・爆弾で想定以上に歩けてしまうバグ
・ランキングの表示順がずれてしまうバグ
・ブロックの数

以上3点を修正

### 実装の概要 / このPRの対応範囲
ブロックの数は30→70に変更。
今後能力ダウンするアイテムを追加するとちょうどいいと思う

### 不安に思っていること
爆弾の歩ける判定は、少し厳しいかも(でも本家もそんな感じ)

