### PR TITLE
アイテム数をヘッダーに表示

### DIFF
--- a/client/src/models/Player.tsx
+++ b/client/src/models/Player.tsx
@@ -11,325 +11,361 @@ import playerRightWalkImg from '../assets/player-right-walk.png'
 import bombImg from '../assets/bomb.png'
 
 export class Player {
-    name: string
-    x: number
-    y: number
-    width: number
-    height: number
-    direction: string
-    pastDirection: string
-    playerImg: string
-    step: number
-    items: Object[] = []
-    bombs: number[][] = []
-    numOfBombs: number = 2
-    bombPower: number = 1
-    isAlive: boolean = true
-    stageMap = { grass: 0, stone: 1, wall: 2, bomb: 3, player: 10, fireH: 11, fireV: 12, fireO: 13, bombUp: 21, fireUp: 22, speedUp: 23}
+  name: string
+  x: number
+  y: number
+  width: number
+  height: number
+  direction: string
+  pastDirection: string
+  playerImg: string
+  step: number = 1
+  items: Object[] = []
+  bombs: number[][] = []
+  numOfBombs: number = 2
+  bombPower: number = 1
+  isAlive: boolean = true
+  static SPEED_UP_ITEM: number = 0.5
+  stageMap = {
+    grass: 0,
+    stone: 1,
+    wall: 2,
+    bomb: 3,
+    player: 10,
+    fireH: 11,
+    fireV: 12,
+    fireO: 13,
+    bombUp: 21,
+    fireUp: 22,
+    speedUp: 23,
+  }
 
-    canvasSize: number = 510
-    numOfBox: number = 17
-    boxSize: number = this.canvasSize / this.numOfBox
-    constructor(
-        name: string,
-    )
-    {
-        this.name = name;
-        this.x = this.boxSize
-        this.y = this.boxSize
-        this.width = 32
-        this.height = 32
-        this.direction = ''
-        this.pastDirection = 'down'
-        this.playerImg = playerFrontImg
-        this.step = 1
+  canvasSize: number = 510
+  numOfBox: number = 17
+  boxSize: number = this.canvasSize / this.numOfBox
+  constructor(name: string) {
+    this.name = name
+    this.x = this.boxSize
+    this.y = this.boxSize
+    this.width = 32
+    this.height = 32
+    this.direction = ''
+    this.pastDirection = 'down'
+    this.playerImg = playerFrontImg
+  }
+
+  getName(): string {
+    return this.name
+  }
+
+  draw(canvas: CanvasRenderingContext2D | null | undefined): void {
+    this.clear(canvas)
+    const img = document.createElement('img')
+    img.src = this.changePlayerImg()
+    canvas?.drawImage(img, this.x, this.y, this.width, this.height)
+  }
+
+  drawBombs(canvas: CanvasRenderingContext2D | null | undefined): void {
+    for (let i = 0; i < this.bombs.length; i++) {
+      const bomb: number[] = this.bombs[i]
+      const img = document.createElement('img')
+      img.src = bombImg
+      canvas?.drawImage(img, bomb[1] * this.boxSize, bomb[0] * this.boxSize, this.width, this.height)
+    }
+  }
+
+  clear(canvas: CanvasRenderingContext2D | null | undefined): void {
+    canvas?.clearRect(0, 0, this.canvasSize, this.canvasSize)
+  }
+
+  stopPlayer(e: any): void {
+    const key: string = e.key
+    if (
+      (this.direction === 'right' && key === 'ArrowRight') ||
+      (this.direction === 'left' && key === 'ArrowLeft') ||
+      (this.direction === 'up' && key === 'ArrowUp') ||
+      (this.direction === 'down' && key === 'ArrowDown')
+    ) {
+      this.pastDirection = this.direction
+      this.direction = ''
+    }
+  }
+
+  changeDirection(e: any): void {
+    if (e.key === 'ArrowRight') {
+      this.direction = 'right'
+    } else if (e.key === 'ArrowUp') {
+      this.direction = 'up'
+    } else if (e.key === 'ArrowLeft') {
+      this.direction = 'left'
+    } else if (e.key === 'ArrowDown') {
+      this.direction = 'down'
+    }
+  }
+
+  move(canvas: CanvasRenderingContext2D | null | undefined, currentStage: number[][]): void {
+    const centerX = this.x + this.width / 2
+    const centerY = this.y + this.height / 2
+    const i: number = this.getIndex(centerY)
+    const j: number = this.getIndex(centerX)
+    // 爆発のなかで止まっているとき、死亡
+    if (currentStage[i][j] > this.stageMap.player && currentStage[i][j] < this.stageMap.bombUp) {
+      this.isAlive = false
+      return
     }
 
-    getName(): string {
-        return this.name
+    if (this.direction === 'up') {
+      this.checkPlayerMove(i, j, this.getIndex(centerY + this.step * -1), j, -1, 'vertical', currentStage)
+    } else if (this.direction === 'down') {
+      this.checkPlayerMove(i, j, this.getIndex(centerY + this.step * 1), j, 1, 'vertical', currentStage)
+    } else if (this.direction === 'left') {
+      this.checkPlayerMove(i, j, i, this.getIndex(centerX + this.step * -1), -1, 'horizontal', currentStage)
+    } else if (this.direction === 'right') {
+      this.checkPlayerMove(i, j, i, this.getIndex(centerX + this.step * 1), 1, 'horizontal', currentStage)
     }
+    this.draw(canvas)
+  }
 
-    draw(canvas: CanvasRenderingContext2D | null | undefined): void {
-        this.clear(canvas)
-        const img = document.createElement('img')
-        img.src = this.changePlayerImg()
-        canvas?.drawImage(
-            img,
-            this.x,
-            this.y,
-            this.width,
-            this.height
-        );
+  getIndex(position: number): number {
+    return Math.floor(position / this.boxSize)
+  }
+
+  checkPlayerMove(
+    i: number,
+    j: number,
+    nextI: number,
+    nextJ: number,
+    direction: number,
+    moveTo: string,
+    currentStage: number[][]
+  ): void {
+    if (this.isOnTheBomb(i, j, direction, moveTo, currentStage)) {
+      this.moveOneStep(i, j, moveTo, direction)
+      return
     }
-
-    drawBombs(canvas: CanvasRenderingContext2D | null | undefined): void{
-        for(let i = 0; i < this.bombs.length; i++){
-            const bomb : number[] = this.bombs[i]
-            const img = document.createElement('img')
-            img.src = bombImg
-            canvas?.drawImage(
-                img,
-                bomb[1] * this.boxSize,
-                bomb[0] * this.boxSize,
-                this.width,
-                this.height
-            )
-        }
-        
+    const bound = this.getBound(moveTo, direction)
+    if (this.hitExplosion(i, j, nextI, nextJ, bound, moveTo, currentStage)) {
+      this.isAlive = false
+    } else if (!this.canMove(i, j, nextI, nextJ, bound, moveTo, currentStage) || this.isOutOfStage(bound)) return
+    else if (nextI !== i || nextJ !== j) {
+      // currentStageのplayerの位置を更新
+      if (currentStage[nextI][nextJ] >= this.stageMap.bombUp) {
+        this.getItem(currentStage[nextI][nextJ])
+      }
+      currentStage[i][j] = this.stageMap.grass
+      currentStage[nextI][nextJ] = this.stageMap.player
     }
+    this.moveOneStep(i, j, moveTo, direction)
+  }
 
-    clear(canvas: CanvasRenderingContext2D | null | undefined): void{
-        canvas?.clearRect(0, 0, this.canvasSize, this.canvasSize);
-    }
-
-    stopPlayer(e: any): void{
-        const key: string = e.key
-        if(
-            (this.direction === 'right' && key === 'ArrowRight') || (this.direction === 'left' && key === 'ArrowLeft') ||
-            (this.direction === 'up' && key === 'ArrowUp') || (this.direction === 'down' && key === 'ArrowDown')
-        ) {
-            this.pastDirection = this.direction
-            this.direction = ''
-        }
-    }
-
-    changeDirection(e: any): void{
-        if(e.key === 'ArrowRight'){
-            this.direction = 'right'
-        } else if (e.key === 'ArrowUp'){
-            this.direction = 'up'
-        } else if (e.key === 'ArrowLeft'){
-            this.direction = 'left'
-        } else if (e.key === 'ArrowDown'){
-            this.direction = 'down'
-        }
-    }
-
-    move(canvas: CanvasRenderingContext2D | null | undefined, currentStage: number[][]): void{
-        const centerX = this.x + this.width / 2
-        const centerY = this.y + this.height / 2
-        const i: number = this.getIndex(centerY)
-        const j: number = this.getIndex(centerX)
-        // 爆発のなかで止まっているとき、死亡
-        if(currentStage[i][j] > this.stageMap.player && currentStage[i][j] < this.stageMap.bombUp){
-            this.isAlive = false
-            return
-        }
-
-        if(this.direction === 'up'){
-            this.checkPlayerMove(i, j, this.getIndex(centerY + this.step * -1), j, -1, 'vertical', currentStage)
-        }
-        else if(this.direction === 'down'){
-            this.checkPlayerMove(i, j, this.getIndex(centerY + this.step * 1), j, 1, 'vertical', currentStage)
-        }
-        else if(this.direction === 'left'){
-            this.checkPlayerMove(i, j, i, this.getIndex(centerX + this.step * -1), -1, 'horizontal', currentStage)
-        }
-        else if(this.direction === 'right'){
-            this.checkPlayerMove(i, j, i, this.getIndex(centerX + this.step * 1), 1, 'horizontal', currentStage)
-        }
-        this.draw(canvas)
-    }
-
-    getIndex(position: number): number{
-        return Math.floor(position / this.boxSize)
-    }
-
-    checkPlayerMove(i: number, j: number, nextI: number, nextJ: number, direction: number, moveTo: string,  currentStage: number[][]): void{
-        if(this.isOnTheBomb(i, j, direction, moveTo, currentStage)){
-            this.moveOneStep(i, j, moveTo, direction)
-            return
-        }
-        const bound = this.getBound(moveTo, direction)
-        if(this.hitExplosion(i, j, nextI, nextJ, bound, moveTo, currentStage)){
-            this.isAlive = false
-        }
-        else if(!this.canMove(i, j, nextI, nextJ, bound, moveTo, currentStage) || this.isOutOfStage(bound)) return
-        
-        else if(nextI !== i || nextJ !== j){
-            // currentStageのplayerの位置を更新
-            if(currentStage[nextI][nextJ] >= this.stageMap.bombUp){
-                this.getItem(currentStage[nextI][nextJ])
-            }
-            currentStage[i][j] = this.stageMap.grass
-            currentStage[nextI][nextJ] = this.stageMap.player
-        }
-        this.moveOneStep(i, j, moveTo, direction)
-    }
-    
-
-    putBomb(e: any, currentStage: number[][]): void {
-        if(e.key === ' '){
-            const i: number = this.getIndex(this.y + this.height / 2)
-            const j: number = this.getIndex(this.x + this.width / 2)
-            if(this.bombs.length < this.numOfBombs){
-                this.bombs.push([i, j])
-                setTimeout(() => {
-                    this.bombs.splice(0, 1)
-                    currentStage[i][j] = this.stageMap.grass
-                    this.explodeBomb(i, j, currentStage)
-                }, 3000);
-                currentStage[i][j] = this.stageMap.bomb
-            }
-        }
-    }
-
-    explodeBomb(i: number, j: number, currentStage: number[][]): void{
-        currentStage[i][j] = this.stageMap.fireO
-        // 4方向の爆発を判定
-        this.explodeDirection(i, j, 1, 0, 1, currentStage, this.stageMap.fireV)
-        this.explodeDirection(i, j, 1, 0, -1, currentStage, this.stageMap.fireV)
-        this.explodeDirection(i, j, 0, 1, 1, currentStage, this.stageMap.fireH)
-        this.explodeDirection(i, j, 0, 1, -1, currentStage, this.stageMap.fireH)
+  putBomb(e: any, currentStage: number[][]): void {
+    if (e.key === ' ') {
+      const i: number = this.getIndex(this.y + this.height / 2)
+      const j: number = this.getIndex(this.x + this.width / 2)
+      if (this.bombs.length < this.numOfBombs) {
+        this.bombs.push([i, j])
         setTimeout(() => {
-            this.removeFire(currentStage)
-        }, 1000);
+          this.bombs.splice(0, 1)
+          currentStage[i][j] = this.stageMap.grass
+          this.explodeBomb(i, j, currentStage)
+        }, 3000)
+        currentStage[i][j] = this.stageMap.bomb
+      }
     }
+  }
 
-    explodeDirection(i: number, j: number, izero: number, jzero: number, direction: number, currentStage: number[][], imgNum: number): void{
-        for(let k:number = 1; k < this.bombPower + 1; k++){
-            const pos = currentStage[i+k*direction*izero][j+k*direction*jzero]
-            if(pos === this.stageMap.wall){
-                break
-            } else if(pos === this.stageMap.stone){
-                this.breakStone(i+k*direction*izero, j+k*direction*jzero, imgNum, currentStage)
-                break
-            } else if(pos === this.stageMap.grass || pos === this.stageMap.player || pos >= this.stageMap.bombUp){
-                currentStage[i+k * direction*izero][j+k*direction* jzero] = imgNum
-            }
-        }
-    }
+  explodeBomb(i: number, j: number, currentStage: number[][]): void {
+    currentStage[i][j] = this.stageMap.fireO
+    // 4方向の爆発を判定
+    this.explodeDirection(i, j, 1, 0, 1, currentStage, this.stageMap.fireV)
+    this.explodeDirection(i, j, 1, 0, -1, currentStage, this.stageMap.fireV)
+    this.explodeDirection(i, j, 0, 1, 1, currentStage, this.stageMap.fireH)
+    this.explodeDirection(i, j, 0, 1, -1, currentStage, this.stageMap.fireH)
+    setTimeout(() => {
+      this.removeFire(currentStage)
+    }, 1000)
+  }
 
-    removeFire(currentStage: number[][]): void{
-        for(let i = 0; i < currentStage.length; i++){
-            for(let j = 0; j < currentStage[i].length; j++){
-                const f = currentStage[i][j]
-                // fire 11 ~
-                if(f > this.stageMap.player && f < 21){
-                    currentStage[i][j] = this.stageMap.grass
-                }
-            }
-        }
+  explodeDirection(
+    i: number,
+    j: number,
+    izero: number,
+    jzero: number,
+    direction: number,
+    currentStage: number[][],
+    imgNum: number
+  ): void {
+    for (let k: number = 1; k < this.bombPower + 1; k++) {
+      const pos = currentStage[i + k * direction * izero][j + k * direction * jzero]
+      if (pos === this.stageMap.wall) {
+        break
+      } else if (pos === this.stageMap.stone) {
+        this.breakStone(i + k * direction * izero, j + k * direction * jzero, imgNum, currentStage)
+        break
+      } else if (pos === this.stageMap.grass || pos === this.stageMap.player || pos >= this.stageMap.bombUp) {
+        currentStage[i + k * direction * izero][j + k * direction * jzero] = imgNum
+      }
     }
-    
-    getBound(moveTo: string, direction: number) : number{
-        let bound: number = 0
-        if(moveTo === 'horizontal'){
-            bound = this.x + this.step * direction
-            if(direction >= 0) bound += this.width
-        } else{
-            bound = this.y + this.step * direction
-            if(direction >= 0) bound += this.height
-        }
-        return bound
-    }
+  }
 
-    isOnTheBomb(i: number, j: number, direction: number, moveTo: string, currentStage: number[][]): boolean{
-        if(moveTo === 'horizontal'){
-            return currentStage[i][j] === this.stageMap.bomb && currentStage[i][j + direction] === 0
-        } else{
-            return currentStage[i][j] === this.stageMap.bomb && currentStage[i + direction][j] === 0
+  removeFire(currentStage: number[][]): void {
+    for (let i = 0; i < currentStage.length; i++) {
+      for (let j = 0; j < currentStage[i].length; j++) {
+        const f = currentStage[i][j]
+        // fire 11 ~
+        if (f > this.stageMap.player && f < 21) {
+          currentStage[i][j] = this.stageMap.grass
         }
+      }
     }
+  }
 
-    isOutOfStage(bound: number): boolean{
-        return this.getIndex(bound) < 0 || this.getIndex(bound) > this.numOfBox - 1
+  getBound(moveTo: string, direction: number): number {
+    let bound: number = 0
+    if (moveTo === 'horizontal') {
+      bound = this.x + this.step * direction
+      if (direction >= 0) bound += this.width
+    } else {
+      bound = this.y + this.step * direction
+      if (direction >= 0) bound += this.height
     }
+    return bound
+  }
 
-    hitExplosion(i: number, j: number, nextI: number, nextJ: number, bound: number, moveTo: string, currentStage: number[][]): boolean{
-        if(currentStage[nextI][nextJ] >= this.stageMap.bombUp || currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp){
-            return false
-        }
-        if(moveTo === 'horizontal'){
-            if(currentStage[nextI][nextJ] >= this.stageMap.bombUp || currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp){
-                return false
-            } else{
-                return currentStage[nextI][nextJ] > this.stageMap.player || currentStage[i][this.getIndex(bound)] > this.stageMap.player
-            }
-        } else{
-            if(currentStage[nextI][nextJ] >= this.stageMap.bombUp || currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp){
-                return false
-            } else{
-                return currentStage[nextI][nextJ] > this.stageMap.player || currentStage[this.getIndex(bound)][j] > this.stageMap.player
-            }
-        }
+  isOnTheBomb(i: number, j: number, direction: number, moveTo: string, currentStage: number[][]): boolean {
+    if (moveTo === 'horizontal') {
+      return currentStage[i][j] === this.stageMap.bomb && currentStage[i][j + direction] === 0
+    } else {
+      return currentStage[i][j] === this.stageMap.bomb && currentStage[i + direction][j] === 0
     }
+  }
 
-    canMove(i: number, j: number, nextI: number, nextJ: number, bound: number, moveTo:string, currentStage: number[][]): boolean{
-        if(moveTo === 'horizontal'){
-            if(currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp){
-                return true
-            }
-            return currentStage[nextI][nextJ] % 10 === 0 && currentStage[i][this.getIndex(bound)] % 10 === 0
-        } else {
-            if(currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp){
-                return true
-            }
-            return currentStage[nextI][nextJ] % 10 === 0 && currentStage[this.getIndex(bound)][j] % 10 === 0
-        }
-    }
+  isOutOfStage(bound: number): boolean {
+    return this.getIndex(bound) < 0 || this.getIndex(bound) > this.numOfBox - 1
+  }
 
-    moveOneStep(i: number, j: number, moveTo: string, direction: number): void{
-        if(moveTo === 'horizontal'){
-            this.y = i * this.boxSize
-            this.x += this.step * direction
-        } else {
-            this.x = j * this.boxSize
-            this.y += this.step * direction
-        }
+  hitExplosion(
+    i: number,
+    j: number,
+    nextI: number,
+    nextJ: number,
+    bound: number,
+    moveTo: string,
+    currentStage: number[][]
+  ): boolean {
+    if (
+      currentStage[nextI][nextJ] >= this.stageMap.bombUp ||
+      currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp
+    ) {
+      return false
     }
+    if (moveTo === 'horizontal') {
+      if (
+        currentStage[nextI][nextJ] >= this.stageMap.bombUp ||
+        currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp
+      ) {
+        return false
+      } else {
+        return (
+          currentStage[nextI][nextJ] > this.stageMap.player ||
+          currentStage[i][this.getIndex(bound)] > this.stageMap.player
+        )
+      }
+    } else {
+      if (
+        currentStage[nextI][nextJ] >= this.stageMap.bombUp ||
+        currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp
+      ) {
+        return false
+      } else {
+        return (
+          currentStage[nextI][nextJ] > this.stageMap.player ||
+          currentStage[this.getIndex(bound)][j] > this.stageMap.player
+        )
+      }
+    }
+  }
 
-    changePlayerImg(): string {
-        let src: string = playerFrontImg
-        if(this.direction === ''){
-            if(this.pastDirection === 'up') src = playerBackImg
-            if(this.pastDirection === 'down') src = playerFrontImg
-            else if(this.pastDirection === 'left') src = playerLeftImg
-            else if(this.pastDirection === 'right') src = playerRightImg
-        } else{
-            if(this.direction === 'down'){
-                src = this.playerImg === playerFrontWalk1Img ? playerFrontWalk2Img : playerFrontWalk1Img
-            }
-            else if(this.direction === 'up'){
-                src = this.playerImg === playerBackWalk1Img ? playerBackWalk2Img : playerBackWalk1Img
-            }
-            else if(this.direction === 'left'){
-                src = this.playerImg === playerLeftImg ? playerLeftWalkImg : playerLeftImg
-            }
-            else if(this.direction === 'right'){
-                src = this.playerImg === playerRightImg ? playerRightWalkImg : playerRightImg
-            }
-        }
-        this.playerImg = src
-        return src
+  canMove(
+    i: number,
+    j: number,
+    nextI: number,
+    nextJ: number,
+    bound: number,
+    moveTo: string,
+    currentStage: number[][]
+  ): boolean {
+    if (moveTo === 'horizontal') {
+      if (currentStage[i][this.getIndex(bound)] >= this.stageMap.bombUp) {
+        return true
+      }
+      return currentStage[nextI][nextJ] % 10 === 0 && currentStage[i][this.getIndex(bound)] % 10 === 0
+    } else {
+      if (currentStage[this.getIndex(bound)][j] >= this.stageMap.bombUp) {
+        return true
+      }
+      return currentStage[nextI][nextJ] % 10 === 0 && currentStage[this.getIndex(bound)][j] % 10 === 0
     }
+  }
 
-    getItem(itemType: number): void{
-        if(itemType === this.stageMap.bombUp){
-            this.numOfBombs++
-            this.items.push(this.stageMap.bombUp)
-        } else if(itemType === this.stageMap.fireUp){
-            this.bombPower++
-            this.items.push(this.stageMap.fireUp)
-        } else if(itemType === this.stageMap.speedUp){
-            this.step += 0.5
-            this.items.push(this.stageMap.speedUp)
-        }
+  moveOneStep(i: number, j: number, moveTo: string, direction: number): void {
+    if (moveTo === 'horizontal') {
+      this.y = i * this.boxSize
+      this.x += this.step * direction
+    } else {
+      this.x = j * this.boxSize
+      this.y += this.step * direction
     }
+  }
 
-    breakStone(i: number, j: number, fireNum: number, currentStage: number[][]): void{
-        let random = Math.random()
-        if(random < 0.6){
-            currentStage[i][j] = fireNum
-        } else{
-            random = Math.random()
-            if(random > 0.5){
-                currentStage[i][j] = this.stageMap.bombUp
-            } else if(random > 0.1){
-                currentStage[i][j] = this.stageMap.fireUp
-            } else{
-                currentStage[i][j] = this.stageMap.speedUp
-            }
-        }
+  changePlayerImg(): string {
+    let src: string = playerFrontImg
+    if (this.direction === '') {
+      if (this.pastDirection === 'up') src = playerBackImg
+      if (this.pastDirection === 'down') src = playerFrontImg
+      else if (this.pastDirection === 'left') src = playerLeftImg
+      else if (this.pastDirection === 'right') src = playerRightImg
+    } else {
+      if (this.direction === 'down') {
+        src = this.playerImg === playerFrontWalk1Img ? playerFrontWalk2Img : playerFrontWalk1Img
+      } else if (this.direction === 'up') {
+        src = this.playerImg === playerBackWalk1Img ? playerBackWalk2Img : playerBackWalk1Img
+      } else if (this.direction === 'left') {
+        src = this.playerImg === playerLeftImg ? playerLeftWalkImg : playerLeftImg
+      } else if (this.direction === 'right') {
+        src = this.playerImg === playerRightImg ? playerRightWalkImg : playerRightImg
+      }
     }
+    this.playerImg = src
+    return src
+  }
+
+  getItem(itemType: number): void {
+    if (itemType === this.stageMap.bombUp) {
+      this.numOfBombs++
+      this.items.push(this.stageMap.bombUp)
+    } else if (itemType === this.stageMap.fireUp) {
+      this.bombPower++
+      this.items.push(this.stageMap.fireUp)
+    } else if (itemType === this.stageMap.speedUp) {
+      this.step += Player.SPEED_UP_ITEM
+      this.items.push(this.stageMap.speedUp)
+    }
+  }
+
+  breakStone(i: number, j: number, fireNum: number, currentStage: number[][]): void {
+    let random = Math.random()
+    if (random < 0.6) {
+      currentStage[i][j] = fireNum
+    } else {
+      random = Math.random()
+      if (random > 0.5) {
+        currentStage[i][j] = this.stageMap.bombUp
+      } else if (random > 0.1) {
+        currentStage[i][j] = this.stageMap.fireUp
+      } else {
+        currentStage[i][j] = this.stageMap.speedUp
+      }
+    }
+  }
 }

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -15,7 +15,7 @@ import { currentStageAtom, playerAtom, enemiesAtom } from '../atom/Atom'
 import { GameRecordGateWay } from '../dataaccess/gameRecordGateway'
 import { GameRecord } from '../dataaccess/recordType'
 import { config1 } from '../bombermanConfig'
-// import { useAddEnemies } from '../hooks/useAddEnemies'
+import { Player } from '../models/Player'
 import useAddEnemies from '../hooks/useAddEnemies'
 
 const Game: React.FC = () => {
@@ -26,37 +26,35 @@ const Game: React.FC = () => {
   const [gameTime, setGameTime] = useState<number>(0)
   const navigate = useNavigate()
   let [enemies] = useAtom(enemiesAtom)
-  const gameRecordGateway = new GameRecordGateWay();
-  const[putNewEnemies] = useAddEnemies()
+  const gameRecordGateway = new GameRecordGateWay()
+  const [putNewEnemies] = useAddEnemies()
 
   useEffect(() => {
     if (gameCanvasRef != null) {
       const a = gameCanvasRef.current?.getContext('2d')
       setCavnasContext(a)
       player.draw(canvasContext)
-
-
-
     }
     addKeyEvents()
     return () => removeKeyEvents()
-
-
   }, [canvasContext])
 
-  useInterval(() => {
-    setGameTime(gameTime + 0.01)
-    player?.move(canvasContext, currentStage)
-    player?.drawBombs(canvasContext)
-    enemies = enemies.filter(enemy => enemy.isAlive)
-    for (let i: number = 0; i < enemies.length; i++) {
-      enemies[i].moveEnemy(canvasContext, currentStage, player);
-      enemies[i].drawEnemy(canvasContext);
-    }
-    if (!player.isAlive) {
-      showResult().catch(() => alert("kkkk"));
-    }
-  }, player.isAlive ? 10 : null)
+  useInterval(
+    () => {
+      setGameTime(gameTime + 0.01)
+      player?.move(canvasContext, currentStage)
+      player?.drawBombs(canvasContext)
+      enemies = enemies.filter((enemy) => enemy.isAlive)
+      for (let i: number = 0; i < enemies.length; i++) {
+        enemies[i].moveEnemy(canvasContext, currentStage, player)
+        enemies[i].drawEnemy(canvasContext)
+      }
+      if (!player.isAlive) {
+        showResult().catch(() => alert('kkkk'))
+      }
+    },
+    player.isAlive ? 10 : null
+  )
 
   useInterval(() => {
     putNewEnemies(2)
@@ -91,7 +89,7 @@ const Game: React.FC = () => {
           name: player.name,
           score: Math.random() * (200 - 100) + 100,
           alivedTime: gameTime,
-        }
+        },
       })
     }, 1000)
     gameRecordGateway.postGameRecord(await getCurrntRecord()).catch(() => alert('ERORR'))
@@ -114,9 +112,18 @@ const Game: React.FC = () => {
           <p className="ml-10 text-xl text-white">00:00</p>
         </div>
         <div className="w-1/3 mx-auto flex justify-around">
-          <div>Item1: </div>
-          <div>Item2:</div>
-          <div>Item3:</div>
+          <div className="flex items-center">
+            <img src={bombUpImg} alt="bombUp" height="40px" width="40px" />
+            <p className="text-2xl text-white ml-2">×{player.numOfBombs - 2}</p>
+          </div>
+          <div className="flex items-center">
+            <img src={fireUpImg} alt="bombUp" height="40px" width="40px" />
+            <p className="text-2xl text-white ml-2">×{player.bombPower - 1}</p>
+          </div>
+          <div className="flex items-center">
+            <img src={speedUpImg} alt="bombUp" height="40px" width="40px" />
+            <p className="text-2xl text-white ml-2">×{(player.step - 1) / Player.SPEED_UP_ITEM}</p>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
### 関連しているIssue / 目的
プレイヤーの能力値からアイテムの個数を判断するようにしました。
ボムの個数と炎の威力は初期にそれぞれ2個、1マス分ですが、どちらも0と表示しました。
デザインの変更はお任せします
