### PR TITLE
オンラインのゲームでも所持アイテム数を表示

### DIFF
--- a/client/src/pages/MultiGame.tsx
+++ b/client/src/pages/MultiGame.tsx
@@ -121,9 +121,18 @@ const MultiGame: React.FC = () => {
           <p>{myPlayer?.name}</p>
         </div>
         <div className="w-1/3 mx-auto flex justify-around">
-          <div>Item1: </div>
-          <div>Item2:</div>
-          <div>Item3:</div>
+          <div className="flex items-center">
+            <img src={bombUpImg} alt="bombUp" height="40px" width="40px" />
+            <p className="text-2xl text-white ml-2">×{myPlayer != null ? myPlayer.numOfBombs - 1 : 0}</p>
+          </div>
+          <div className="flex items-center">
+            <img src={fireUpImg} alt="bombUp" height="40px" width="40px" />
+            <p className="text-2xl text-white ml-2">×{myPlayer != null ? myPlayer.bombPower - 1 : 0}</p>
+          </div>
+          <div className="flex items-center">
+            <img src={speedUpImg} alt="bombUp" height="40px" width="40px" />
+            <p className="text-2xl text-white ml-2">×{myPlayer != null ? myPlayer.speed - 3 : 0}</p>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
### 関連しているIssue / 目的
#81 

### 達成条件
自分が所持しているアイテム数をヘッダーに表示
プレイヤーが死亡したら全アイテムの所持数を0にしました

### 重点的にレビューして欲しいところ
特になし
