### PR TITLE
ゲーム開始から2分後にステージを縮小

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,8 +11,8 @@ import Lobby from './pages/Lobby'
 import MultiGame from './pages/MultiGame'
 import MultiResult from './pages/MultiResult'
 
-// const CONNECTION_PORT = 'localhost:3001'
-const CONNECTION_PORT = 'https://bomberman-server-2023.an.r.appspot.com'
+const CONNECTION_PORT = 'localhost:3001'
+// const CONNECTION_PORT = 'https://bomberman-server-2023.an.r.appspot.com'
 
 const App: React.FC = () => {
   const [socket, setSocket] = useAtom(socketAtom)

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,8 +25,8 @@ export const rooms = [
 app.use(cors());
 app.use(express.json());
 
-const server = app.listen(process.env.PORT || 8080, () => {
-  // const server = app.listen("3001", () => {
+// const server = app.listen(process.env.PORT || 8080, () => {
+const server = app.listen("3001", () => {
   console.log("Server is Running");
 });
 

--- a/server/player.ts
+++ b/server/player.ts
@@ -56,6 +56,10 @@ export class Player {
 
   move(stage: Stage): void {
     const board = stage.getStage();
+    if (this.isInBlock(board)) {
+      this.isAlive = false;
+      this.killedBy = "Wall";
+    }
     if (this.canMove(board) && this.direction !== "stay") {
       this.moveOneStep();
     }
@@ -192,6 +196,13 @@ export class Player {
     playerIndex.j = Math.floor((this.x + this.size / 2) / Stage.boxSize);
     const stageValue = board[playerIndex.i][playerIndex.j];
     return stageValue >= Stage.stageValues.bombUp;
+  }
+
+  isInBlock(board: number[][]): boolean {
+    const playerIndex: Index = new Index();
+    playerIndex.i = Math.floor((this.y + this.size / 2) / Stage.boxSize);
+    playerIndex.j = Math.floor((this.x + this.size / 2) / Stage.boxSize);
+    return board[playerIndex.i][playerIndex.j] === Stage.stageValues.wall;
   }
 
   getItem(board: number[][]): void {

--- a/server/room.ts
+++ b/server/room.ts
@@ -14,6 +14,7 @@ export class Room {
   roomName: string;
   stage: Stage;
   gameStartTime: number;
+  isShrinking: boolean = false;
   constructor(roomName: string) {
     this.roomName = roomName;
     this.stage = new Stage();
@@ -21,6 +22,10 @@ export class Room {
 
   startGame(): void {
     this.gameStartTime = new Date().getTime();
+  }
+
+  getGameTime(): number {
+    return (new Date().getTime() - this.gameStartTime) / 1000;
   }
 
   getPlayer(playerId: number): Player | null {
@@ -43,15 +48,25 @@ export class Room {
 
   // dead
   removePlayer(player: Player): void {
-    let deathTime = (new Date().getTime() - this.gameStartTime) / 1000;
+    let deathTime = this.getGameTime();
     this.players = this.players.filter((p) => p.playerId !== player.playerId);
-    if (this.players.length === 0)
-      deathTime = (new Date().getTime() - this.gameStartTime) / 100;
+    if (this.players.length === 0) deathTime = this.getGameTime() + 10;
     this.deadPlayers.push({
       name: player.name,
       playerId: player.playerId,
       deathTime,
       killedBy: player.killedBy,
     });
+  }
+
+  async startShrink(): Promise<void> {
+    this.isShrinking = true;
+    let sideLen: number = 15;
+    let start: number = 1;
+    while (sideLen > 8) {
+      await this.stage.shrinkAround(sideLen, start);
+      sideLen -= 2;
+      start += 1;
+    }
   }
 }

--- a/server/stage.ts
+++ b/server/stage.ts
@@ -82,4 +82,28 @@ export class Stage {
     // this.bombs = this.bombs.filter((b) => b.id !== bomb.id);
     bomb.explode();
   }
+
+  async shrinkAround(sideLen: number, start: number): Promise<void> {
+    for (let j = start; j < start + sideLen; j++) {
+      await this.changeBlock(start, j);
+    }
+    for (let i = start + 1; i < start + sideLen; i++) {
+      await this.changeBlock(i, start + sideLen - 1);
+    }
+    for (let j = start + sideLen - 2; j >= start; j--) {
+      await this.changeBlock(start + sideLen - 1, j);
+    }
+    for (let i = start + sideLen - 2; i > start; i--) {
+      await this.changeBlock(i, start);
+    }
+  }
+
+  async changeBlock(i: number, j: number): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this.board[i][j] = Stage.stageValues.wall;
+        resolve();
+      }, 200);
+    });
+  }
 }

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -43,6 +43,9 @@ export const playerInterval = (socket, data) => {
     finishGame(socket, room);
   }
   sendGameStatus(room, socket);
+  if (!room.isShrinking && room.getGameTime() > 120) {
+    room.startShrink();
+  }
 };
 
 export const playerBomb = (socket, data) => {


### PR DESCRIPTION
### 関連しているIssue / 目的

### 達成条件
ゲーム開始から2分後(仮の時間)にステージを縮小させていく
ステージのサイズが十分に小さくなったら縮小を止めてあとはプレイヤーが爆弾を当てあうのを待つ

プレイヤーがステージに埋まったら死亡。KilledByには"Wall"を表示させる

### 重点的にレビューして欲しいところ
特になし

毎回2分待つの面倒だと思うので一応動画も貼っておくので見てみてください
https://clipchamp.com/watch/c6pIeml9KHk