### PR TITLE
instanceクラスを上げる

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -1,7 +1,7 @@
 env: standard
 runtime: nodejs16
 default_expiration: "12h"
-instance_class: F1
+instance_class: F4
 automatic_scaling:
   target_cpu_utilization: 0.95
   target_throughput_utilization: 0.95


### PR DESCRIPTION
app engineのinstanceクラスを上げました。
微課金が発生しやすくなるので、開発の際はローカルでポートを変更してして欲しいです。
2月4日になる、もしくは想定以上の課金が発生しましたら元に戻す予定です。
