### PR TITLE
初期位置でも当たり判定をつける

### DIFF
--- a/client/src/models/Player.tsx
+++ b/client/src/models/Player.tsx
@@ -153,10 +153,14 @@ export class Player {
       if (currentStage[nextI][nextJ] >= this.stageMap.bombUp) {
         this.getItem(currentStage[nextI][nextJ])
       }
-      currentStage[i][j] = this.stageMap.grass
-      currentStage[nextI][nextJ] = this.stageMap.player
+      this.changePlayerIndex(i, j, nextI, nextJ, currentStage)
     }
     this.moveOneStep(i, j, moveTo, direction)
+  }
+
+  changePlayerIndex(i: number, j: number, nextI: number, nextJ: number, currentStage: number[][]): void {
+    currentStage[i][j] = this.stageMap.grass
+    currentStage[nextI][nextJ] = this.stageMap.player
   }
 
   putBomb(e: any, currentStage: number[][]): void {

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -70,6 +70,7 @@ const Game: React.FC = () => {
       removeKeyEvents()
       if (count === 1) {
         setCount('GAME START')
+        player.changePlayerIndex(1, 1, 1, 1, currentStage)
         setTimeout(() => {
           document.querySelectorAll('.overlay')[0].classList.remove('overlay')
           setCount('')


### PR DESCRIPTION
### 関連しているIssue / 目的
ソロプレイ時にプレイヤーが初期位置から動かないとエネミーの当たり判定が効かないバグを修正。
