### PR TITLE
マルチゲーム画面とランキング画面のデザイン変更

### DIFF
--- a/client/src/pages/MultiGame.tsx
+++ b/client/src/pages/MultiGame.tsx
@@ -145,7 +145,7 @@ const MultiGame: React.FC = () => {
       <div className="h-20 bg-slate-600 flex items-center">
         <div className="w-1/3 ml-20">
           <div>
-            <p className='text-red-500'><span className='text-white'>Your:</span>{myPlayer?.name}</p>
+            <p className='text-red-500'><span className='text-white'>You are:</span>{myPlayer?.name}</p>
             
           </div>
           

--- a/client/src/pages/Ranking.tsx
+++ b/client/src/pages/Ranking.tsx
@@ -29,43 +29,47 @@ const Ranking: React.FC = () => {
   }
 
   return (
-    <div className='bg-black'>
+    <div className='h-screen bg-black'>
       <div className="h-20 flex items-center justify-center">
         <p className="text-center text-4xl text-white mt-10">RANKING</p>
       </div>
       <button className="ml-40 nes-btn is-error p-2 text-white" onClick={navigateHome}>
         Back
       </button>
-      <div className="flex h-1/2 w-1/2 mx-auto mt-5 pt-6 text-white">
-        <div className="w-1/3">
-          <p>Rnak</p>
-          {records?.map((record: GameRecord, index) => (
-            <div key={record.id}>
-              <p className="text-start my-4 text-2xl">{index + 1}</p>
+      <div className='flex justify-center h-2/3 mt-10'>
+        <div className='nes-container is-dark w-3/4 overflow-y-scroll'>
+          
+          <div className="pt-6 text-white flex justify-between">
+            <div className="ml-20">
+              <p>Rnak</p>
+              {records?.map((record: GameRecord, index) => (
+                <div className='h-10' key={record.id}>
+                  <p className="text-start my-4 text-2xl">{index + 1}</p>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-        <div className="w-1/3">
-          <p>name</p>
-          {records?.map((record: GameRecord, index) => (
-            <div key={record.id}>
-              <p className="text-start my-4 text-2xl">{record.name}</p>
+            <div className="">
+              <p>name</p>
+              {records?.map((record: GameRecord, index) => (
+                <div className='h-10' key={record.id}>
+                  <p className="text-start my-4 text-2xl">{record.name}</p>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-        <div className="w-1/3">
-          <p>score</p>
-          {records?.map((record: GameRecord) => (
-            <div key={record.id}>
-              <p className="text-start my-4 text-2xl">
-                {convertTimeToScore(record.score).slice(0, 6)}
-                <span className="text-lg">{convertTimeToScore(record.score).slice(-2)}</span>
-              </p>
+            <div className="mr-10">
+              <p>score</p>
+              {records?.map((record: GameRecord) => (
+                <div className='h-10' key={record.id}>
+                  <p className="text-start my-4 text-2xl">
+                    {convertTimeToScore(record.score).slice(0, 6)}
+                    <span className="text-lg">{convertTimeToScore(record.score).slice(-2)}</span>
+                  </p>
+                </div>
+              ))}
             </div>
-          ))}
+          </div>
         </div>
       </div>
-      
     </div>
   )
 }


### PR DESCRIPTION
### 関連しているIssue / 目的

### 達成条件
- []  ランキング画面の背景色を黒くする
- []  マルチゲーム画面ヘッダーの名前を変更

### 実装の概要 / このPRの対応範囲
ランキング画面は、ランキングをコンテナの中に入れて、画面のサイズを常に一定にすることで背景色を常に黒にすることができました。
ヘッダーの名前の部分は、
「Your: GUESTUSER」から「You are: GUESTUSER」に変更しました。

### 重点的にレビューして欲しいところ
ランキング画面に遷移した時に白が出ず、背景色が常に黒くなっていること
ヘッダーの名前部分が変更されていること

### 不安に思っていること
特にありません。

### その他情報（スクリーンショット等）
